### PR TITLE
fix: remove external exposure of None and Some

### DIFF
--- a/src/none.ts
+++ b/src/none.ts
@@ -1,4 +1,4 @@
-import Maybe, { MatchType, Nil } from "./maybe";
+import Maybe, { MatchType } from "./maybe";
 import { maybe } from "index";
 
 export default class None<T> extends Maybe<T> {
@@ -20,11 +20,11 @@ export default class None<T> extends Maybe<T> {
             this as any;
     }
 
-    map<U>(f: (v: T) => (U | Nil)): Maybe<U> {
+    map<U>(): Maybe<U> {
         return this as any;
     }
 
-    flatMap<U>(f: (v: T) => Maybe<U>): Maybe<U> {
+    flatMap<U>(): Maybe<U> {
         return this as any;
     }
 
@@ -43,4 +43,4 @@ export default class None<T> extends Maybe<T> {
     asNullable(): T | null { return null; }
 }
 
-export const none = None.none;
+export const none: <T>() => Maybe<T> = None.none;

--- a/src/some.ts
+++ b/src/some.ts
@@ -32,4 +32,4 @@ export default class Some<T> extends Maybe<T> {
     }
 }
 
-export const some = Some.some;
+export const some: <T>(x: T) => Maybe<T> = Some.some;


### PR DESCRIPTION
Can simplify some of the typescript contracts by making the `some` and
`none` methods return type `Maybe` instead of types `Some` and `None`
respectively. This will make the TS types use the more generic `Maybe`
versions instead of the specific classes.