### PR TITLE
build: keep npm cache between builds to speed npm install time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ notifications:
   email:
     on_success: never
     on_failure: always
+cache:
+  directories:
+    - $HOME/.npm


### PR DESCRIPTION
Small change, just trying to be a good citizen of the free service travis provides :)