### PR TITLE
Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - npm install
 script:
   - npm run test
+  - npx codecov -t $CODECOV_TOKEN
 deploy:
   provider: script
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/andnp/MaybeTyped.svg?branch=master)](https://travis-ci.org/andnp/MaybeTyped)
 [![Greenkeeper badge](https://badges.greenkeeper.io/andnp/MaybeTyped.svg)](https://greenkeeper.io/)
+[![codecov](https://codecov.io/gh/andnp/MaybeTyped/branch/master/graph/badge.svg)](https://codecov.io/gh/andnp/MaybeTyped)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 MaybeTyped is a well-typed Maybe (optional) monad written in typescript.
 

--- a/src/none.ts
+++ b/src/none.ts
@@ -13,12 +13,9 @@ export default class None<T> extends Maybe<T> {
 
     static none<T>() { return new None<T>(); }
 
-    expect(msg?: string | Error) {
+    expect(msg?: string | Error): T {
         if (msg instanceof Error) throw msg;
         throw new Error(msg || 'Expected Maybe to contain non-null value');
-
-        // @ts-ignore -- need to return type T, but this is unreachable code
-        return this.value!;
     }
 
     caseOf<R>(funcs: MatchType<T, R>): Maybe<R> {

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -89,6 +89,18 @@ test('expect - Throws error when nil', () => {
     }).toThrow();
 });
 
+test('expect - Throws specified message when nil', () => {
+    expect(() => {
+        none().expect('oops....');
+    }).toThrow('oops....');
+});
+
+test('expect - Throws specified error when nil', () => {
+    expect(() => {
+        none().expect(new Error('uh-oh'));
+    }).toThrowError('uh-oh');
+});
+
 // --
 // or
 // --
@@ -174,6 +186,26 @@ test('caseOf - calls "none" function when nil', () => {
 
     none().caseOf({
         some: raiseError,
+        none: () => expect(true).toBe(true),
+    });
+});
+
+test('caseOf - can be provided subset of matcher functions', () => {
+    expect.assertions(2);
+
+    some('hey').caseOf({
+        none: raiseError,
+    });
+
+    none().caseOf({
+        some: raiseError,
+    });
+
+    some('hey').caseOf({
+        some: v => expect(v).toBe('hey'),
+    });
+
+    none().caseOf({
         none: () => expect(true).toBe(true),
     });
 });


### PR DESCRIPTION
Usually code coverage isn't the _most_ meaningful measurement of unit test coverage, but it is the easiest to collect and display. A lot of guides for "how to promote your library" say that having 100% test coverage - and being able to prove it - help dramatically.