### PR TITLE
perf: create single shared none instance

### DIFF
--- a/src/none.ts
+++ b/src/none.ts
@@ -51,4 +51,5 @@ export default class None<T> extends Maybe<T> {
     asNullable(): T | null { return null; }
 }
 
-export const none: <T>() => Maybe<T> = None.none;
+const _noneSingleton = None.none<any>();
+export const none = <T>(): Maybe<T> => _noneSingleton;


### PR DESCRIPTION
Because all nones are equivalent, we can share a single instance. This
should save a decent amount of memory and cpu cycles from not building
the `None` class constantly.