### PR TITLE
chore: use TSlib for TS helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "branch": "master"
   },
   "dependencies": {
-    "simplytyped": "^1.0.5"
+    "simplytyped": "^1.0.5",
+    "tslib": "^1.9.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "target": "es5",
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "importHelpers": true,
         "declaration": true,
         "lib": [
             "es2015",


### PR DESCRIPTION
By using TSlib, any dependent TS library can reduce their bundle size.

This is a decently opinionated change: if a consuming library is _not_
using TS and TSlib, their app size goes up with this change. If the
library is using both, their app size goes down with this change.

In general if more libraries that rely on TS used `importHelpers` and
TSlib, app sizes would decrease notably.

A follow-up PR will do some related work by making es6 exports available
via the `module` package.json field.