### PR TITLE
build: pin ts-jest version due to breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "^4.1.3",
     "rollup": "^0.66.0",
     "rollup-plugin-typescript2": "^0.17.0",
-    "ts-jest": "^23.0.0",
+    "ts-jest": "23.10.0",
     "ts-node": "^7.0.0",
     "tslint": "^5.9.1",
     "typescript": "^2.8.1"


### PR DESCRIPTION
This is coming from [this issue](https://github.com/kulshekhar/ts-jest/issues/748)