### PR TITLE
Revert "Update rollup-plugin-typescript2 to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^24.0.0",
     "npm-run-all": "^4.1.3",
     "rollup": "^1.0.0",
-    "rollup-plugin-typescript2": "^0.20.0",
+    "rollup-plugin-typescript2": "^0.19.0",
     "ts-jest": "24.0.0",
     "ts-node": "^8.0.3",
     "tslint": "^5.13.0",


### PR DESCRIPTION
Reverts andnp/MaybeTyped#54

This is causing build issues.
```
./src/index.ts → dist/index.js...
[!] Error: Entry module cannot be external
Error: Entry module cannot be external
    at error (/home/andy/Projects/opensource/maybetyped/node_modules/.registry.npmjs.org/rollup/1.6.0/node_modules/rollup/dist/rollup.js:3601:30)
    at /home/andy/Projects/opensource/maybetyped/node_modules/.registry.npmjs.org/rollup/1.6.0/node_modules/rollup/dist/rollup.js:17933:17
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
```

I can't seem to find anything on google about it, and I don't have time to be chasing these down right now.