### PR TITLE
test: attempt build in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
 install:
   - npm install
 script:
+  - npm run tsc
   - npm run test
+  - npm run build
   - npx codecov -t $CODECOV_TOKEN
 deploy:
   provider: script

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",
   "scripts": {
+    "build": "rm -rf dist && run-s rollup/cjs rollup/esm",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "tslint --config tslint.json --project . --format stylish",
     "test": "jest",
@@ -13,7 +14,7 @@
     "rollup/esm": "rollup --format esm --config rollup.config.js --file dist/index.mjs",
     "tsc": "tsc",
     "prepush": "run-s lint test",
-    "release": "rm -rf dist && run-s rollup/cjs rollup/esm && npx semantic-release"
+    "release": "run-s build && npx semantic-release"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I had a break yesterday when merging a PR from greenkeeper upgrading the rollup-typescript plugin. This is because my CI doesn't attempt to create a rollup build during testing. This PR will fix that, reducing the chances of rollup breaking my build again in the future.