### PR TITLE
feat: 🎸 prevent mapping with void functions (WIP?)

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -5,6 +5,8 @@ export const binder = <T extends Function>(context: any, f: T): T => f.bind(cont
 
 export type Nil = null | undefined;
 
+export type NotVoid = object | string | number | boolean | undefined | null;
+
 export interface MatchType<T, R> {
     some?: (v: T) => R;
     none?: () => R;
@@ -23,7 +25,7 @@ export default abstract class Maybe<T> {
 
     abstract expect(msg?: string | Error): T;
     abstract caseOf<R>(funcs: MatchType<T, R>): Maybe<R>;
-    abstract map<U>(f: (v: T) => Nullable<U>): Maybe<U>;
+    abstract map<U extends NotVoid>(f: (v: T) => Nullable<U>): Maybe<U>;
     abstract tap(f: (v: T) => void): Maybe<T>;
     abstract flatMap<U>(f: (v: T) => Maybe<U>): Maybe<U>;
     abstract orElse<U>(def: U | (() => U)): T | U;
@@ -31,11 +33,11 @@ export default abstract class Maybe<T> {
     abstract eq(other: Maybe<T>): boolean;
     abstract asNullable(): T | null;
 
-    abstract join<U, R>(f: (x: T, y: U) => R | Nil, other: Maybe<U>): Maybe<R>;
+    abstract join<U, R extends NotVoid>(f: (x: T, y: U) => R | Nil, other: Maybe<U>): Maybe<R>;
 
     // Fantasy-land aliases
     static [fl.of]: <T>(x: T) => Maybe<T>;
     [fl.map] = binder(this, this.map);
     [fl.chain] = binder(this, this.flatMap);
-    [fl.ap]: <U>(m: Maybe<(x: T) => U>) => Maybe<U> = m => m.flatMap(f => this.map(f));
+    [fl.ap]: <U extends NotVoid>(m: Maybe<(x: T) => U>) => Maybe<U> = m => m.flatMap(f => this.map(f));
 }

--- a/src/some.ts
+++ b/src/some.ts
@@ -1,5 +1,5 @@
 import { Nullable } from 'simplytyped';
-import Maybe, { MatchType } from "./maybe";
+import Maybe, { MatchType, NotVoid } from "./maybe";
 import { maybe, none } from "./index";
 
 export default class Some<T> extends Maybe<T> {
@@ -40,7 +40,7 @@ export default class Some<T> extends Maybe<T> {
             .orElse(false);
     }
 
-    join<U, R>(f: (x: T, y: U) => Nullable<R>, other: Maybe<U>): Maybe<R> {
+    join<U, R extends NotVoid>(f: (x: T, y: U) => Nullable<R>, other: Maybe<U>): Maybe<R> {
         return this.flatMap(x => other.map(y => f(x, y)));
     }
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,6 +1,6 @@
 import { ConstructorFor, Nullable } from 'simplytyped';
 // @ts-ignore
-import Maybe, { MatchType, Nil } from './maybe';
+import Maybe, { MatchType, Nil, NotVoid } from './maybe';
 import { maybe } from './index';
 
 export interface Monad<T> {
@@ -29,7 +29,7 @@ export class MaybeT<T extends MonadLike<unknown>> {
         return new MaybeT(monad);
     }
 
-    map<U>(f: (v: MaybeValue<T>) => U): MaybeT<Monad<U>> {
+    map<U extends NotVoid>(f: (v: MaybeValue<T>) => U): MaybeT<Monad<U>> {
         const map = getMap(this.value);
         return new MaybeT(map(inner =>
             maybe(inner)

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -4,7 +4,7 @@ import Maybe, { maybe, none, some } from '../src';
 // Helpers
 // -------
 const execEach = (...args: Array<() => any>) => () => args.forEach(arg => arg());
-const noop = () => { /* stub */ };
+const noop = () => null;
 const raiseError = () => {
     throw new Error('oops');
 };
@@ -38,7 +38,8 @@ test('Calls map function when contained value is non-nil', () => {
     const value = "i'm not nil";
     const definitely = some(value);
 
-    definitely.map(v => expect(v).toBe(value));
+    // `void` to avoid passing void function to map
+    definitely.map(v => void expect(v).toBe(value));
 });
 
 test('Does not call map function when contained value is nil', () => {
@@ -272,7 +273,7 @@ test('join - calls f if both sides are some', () => {
 
     const z = x.join((a, b) => a + b, y);
 
-    z.map(c => expect(c).toBe('hi there'));
+    z.tap(c => expect(c).toBe('hi there'));
 });
 
 test('join - does not call f if either side is none', () => {
@@ -286,9 +287,9 @@ test('join - does not call f if either side is none', () => {
     const z2 = right.join((a, b) => a + b, left);
     const z3 = right.join((a, b) => a + b, middle);
 
-    z1.map(fail).orElse(pass);
-    z2.map(fail).orElse(pass);
-    z3.map(fail).orElse(pass);
+    z1.tap(fail).orElse(pass);
+    z2.tap(fail).orElse(pass);
+    z3.tap(fail).orElse(pass);
 });
 
 // -------
@@ -301,5 +302,6 @@ test('fantasy-land/map - calls into the map method', () => {
     const value = "i'm not nil";
     const definitely = some(value);
 
-    definitely["fantasy-land/map"](v => expect(v).toBe(value));
+    // `void` to avoid passing void function to map
+    definitely["fantasy-land/map"](v => void expect(v).toBe(value));
 });


### PR DESCRIPTION
This is a potential implementation of the changes described in #76.  Disallowing `void` functions from being passed to `.map` turned out to be more tricky than I initially thought.

This works, but with a major caveat: it also blocks functions that return `undefined`.  I couldn't find a way to permit `unknown` without permitting `void`, (as `void` is assignable to `unknown`).  They'd have to cast their `unknown`s as `NotVoid`.

---

So I'm not completely happy with this change; I'm putting it up as something between a WiP and a PoC.